### PR TITLE
Deprecate the ConfigInterface. No need for an interface with no methods

### DIFF
--- a/src/Connection/BaseConfiguration.php
+++ b/src/Connection/BaseConfiguration.php
@@ -9,7 +9,7 @@ use GraphAware\Common\Driver\ConfigInterface;
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class Configuration implements ConfigInterface
+class BaseConfiguration implements ConfigInterface
 {
     /**
      * @var array

--- a/src/Connection/Configuration.php
+++ b/src/Connection/Configuration.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace GraphAware\Common\Connection;
+
+use GraphAware\Common\Driver\ConfigInterface;
+
+/**
+ * A shared configuration class between connection. The configuration class is immutable.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class Configuration implements ConfigInterface
+{
+    /**
+     * @var array
+     */
+    private $data;
+
+    /**
+     * Init the configuration with some data.
+     *
+     * @param array $data
+     */
+    protected function __construct(array $data = [])
+    {
+        $this->data = $data;
+    }
+
+    /**
+     * Factory function for the configuration.
+     *
+     * @return static
+     */
+    public static function create()
+    {
+        return new static();
+    }
+
+    /**
+     * @param string $name
+     * @param mixed  $default value when $name is not defined
+     *
+     * @return mixed
+     */
+    public function getValue($name, $default = null)
+    {
+        if (!isset($this->data[$name])) {
+            return $default;
+        }
+
+        return $this->data[$name];
+    }
+
+    /**
+     * Does the data exist in the configuration?
+     *
+     * @param string $name
+     *
+     * @return bool
+     */
+    public function hasValue($name)
+    {
+        return isset($this->data[$name]);
+    }
+
+    /**
+     * Create a new Configuration with a new $value for key $name.
+     * Any existing value for $name will be replaced in the new Configuration instance.
+     *
+     * @param string $name
+     * @param mixed  $value
+     *
+     * @return static
+     */
+    public function setValue($name, $value)
+    {
+        $new = clone $this;
+        $new->data[$name] = $value;
+
+        return $new;
+    }
+}

--- a/src/Driver/ConfigInterface.php
+++ b/src/Driver/ConfigInterface.php
@@ -11,6 +11,9 @@
 
 namespace GraphAware\Common\Driver;
 
+/**
+ * @deprecated Will be removed i 4.0.
+ */
 interface ConfigInterface
 {
 }

--- a/src/GraphDatabaseInterface.php
+++ b/src/GraphDatabaseInterface.php
@@ -11,14 +11,15 @@
 
 namespace GraphAware\Common;
 
+use GraphAware\Common\Connection\Configuration;
 use GraphAware\Common\Driver\ConfigInterface;
 use GraphAware\Common\Driver\DriverInterface;
 
 interface GraphDatabaseInterface
 {
     /**
-     * @param string               $uri
-     * @param ConfigInterface|null $config
+     * @param string                             $uri
+     * @param ConfigInterface|Configuration|null $config
      *
      * @return DriverInterface
      */

--- a/src/GraphDatabaseInterface.php
+++ b/src/GraphDatabaseInterface.php
@@ -19,7 +19,7 @@ interface GraphDatabaseInterface
 {
     /**
      * @param string                             $uri
-     * @param ConfigInterface|Configuration|null $config
+     * @param Configuration|null $config
      *
      * @return DriverInterface
      */

--- a/src/GraphDatabaseInterface.php
+++ b/src/GraphDatabaseInterface.php
@@ -11,15 +11,15 @@
 
 namespace GraphAware\Common;
 
-use GraphAware\Common\Connection\Configuration;
+use GraphAware\Common\Connection\BaseConfiguration;
 use GraphAware\Common\Driver\ConfigInterface;
 use GraphAware\Common\Driver\DriverInterface;
 
 interface GraphDatabaseInterface
 {
     /**
-     * @param string                             $uri
-     * @param Configuration|null $config
+     * @param string             $uri
+     * @param BaseConfiguration|null $config
      *
      * @return DriverInterface
      */


### PR DESCRIPTION
The interface does not provide any type safety. The two implementations BoltConfiguration and HttpConfiguration has nothing in common. They are two very different classes but they have the same purpose. 

As an alternative solution would could make a generic Configuration class with methods like:

```php
Configuration::hasValue(string $name);
Configuration::setValue(string $name, mixed $value);
Configuration::getValue(string $name);
```

Related to https://github.com/graphaware/neo4j-php-client/issues/95 and https://github.com/graphaware/neo4j-bolt-php/issues/19