### PR TITLE
Added branch alias to 3.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,5 +27,10 @@
       "psr-4": {
         "GraphAware\\Common\\Tests\\": "tests/"
       }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.4-dev"
+        }
     }
 }


### PR DESCRIPTION
When this is in master one could write: 

```
composer require graphaware/neo4j-common:^3.4

// Same as
composer require graphaware/neo4j-common:dev-master
```